### PR TITLE
Upload buildkite pipeline config

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,14 @@
+steps:
+  - label: ":bazel: Build & Test"
+    timeout_in_minutes: 30
+    commands:
+      - "set -euo pipefail"
+      - 'export PATH="$PWD/.buildkite/bin:$PATH"'
+      - 'mkdir -p .buildkite/bin ~/.cache/bazel ~/.cache/bazelisk ~/.cache/bazel-disk-cache ~/.cache/bazel-repo'
+      - 'if ! command -v bazel >/dev/null 2>&1; then if command -v curl >/dev/null 2>&1; then curl -sSL --retry 3 -o .buildkite/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.26.0/bazelisk-linux-amd64; else wget -q -O .buildkite/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.26.0/bazelisk-linux-amd64; fi; chmod +x .buildkite/bin/bazel; fi'
+      - 'if [ -n "${BUILDBUDDY_API_KEY:-}" ]; then cat > .bazelrc.remote.ci << EOF\ncommon --remote_cache=grpcs://remote.buildbuddy.io\ncommon --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}\ncommon --remote_timeout=60s\ncommon --remote_upload_local_results=true\ncommon --bes_results_url=https://app.buildbuddy.io/invocation/\ncommon --remote_executor=grpcs://remote.buildbuddy.io\ncommon --remote_local_fallback\ncommon --strategy=TestRunner=remote,local\ncommon --strategy=GoLink=remote,local\ncommon --strategy=GoCompile=remote,local\ncommon --remote_cache_compression\ncommon --remote_download_toplevel\nEOF\necho "Configured BuildBuddy remote cache"; else echo "Skipping BuildBuddy remote cache"; fi'
+      - 'DOCKER_OK=1; command -v docker >/dev/null 2>&1 || DOCKER_OK=0; [ $DOCKER_OK -eq 1 ] && docker info >/dev/null 2>&1 || DOCKER_OK=0; if [ $DOCKER_OK -eq 0 ]; then echo "Docker not available; excluding integration/local tests"; TEST_FILTERS="--test_tag_filters=-integration,-local"; else echo "Docker available"; TEST_FILTERS=""; fi'
+      - 'bazel --version || true'
+      - 'bazel test --config=ci --test_output=errors ${TEST_FILTERS} //...'
+    artifact_paths:
+      - "bazel-testlogs/**/test.log"


### PR DESCRIPTION
Add a Buildkite pipeline configuration file (`.buildkite/pipeline.yml`) to enable `buildkite-agent pipeline upload` for Bazel-only projects.

---
<a href="https://cursor.com/background-agent?bcId=bc-eeede932-e0a7-4137-b3bb-ef0ac1d94109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eeede932-e0a7-4137-b3bb-ef0ac1d94109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

